### PR TITLE
mysqlclient 2.2.8 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mysqlclient" %}
-{% set version = "2.2.7" %}
+{% set version = "2.2.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/PyMySQL/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 518f256556b518bd947cdd682b4d7c2263427588296e77cc1f30e5b95f5be13f
+  sha256: b9de84686fa6bfc3c876aab075e92097bd79e71b457d08eb7510c0df009db96a
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   # Skipping Windows due to build challenges, reliance on mariadbclient which is not available
-  skip: true  # [py<38 or win]
+  skip: true  # [py<310 or win]
 
 requirements:
   build:


### PR DESCRIPTION
mysqlclient 2.2.8 

**Destination channel:** Defaults

### Links

- [PKG-12447]
- dev_url:        https://github.com/PyMySQL/mysqlclient/tree/v2.2.8
- conda_forge:    https://github.com/conda-forge/mysqlclient-feedstock
- pypi:           https://pypi.org/project/mysqlclient/2.2.8
- pypi inspector: https://inspector.pypi.io/project/mysqlclient/2.2.8

### Explanation of changes:

- new version number


[PKG-12447]: https://anaconda.atlassian.net/browse/PKG-12447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ